### PR TITLE
Add missing send-event mode to sway-input(5)

### DIFF
--- a/sway/sway-input.5.txt
+++ b/sway/sway-input.5.txt
@@ -30,7 +30,7 @@ Commands
 **input** <identifier> dwt <enabled|disabled>::
 	Enables or disables disable-while-typing for the specified input device.
 
-**input** <identifier> events <enable|disabled>::
+**input** <identifier> events <enabled|disabled|disabled_on_external_mouse>::
 	Enables or disables send_events for specified input device.
 	(Disabling  send_events disables the input device)
 


### PR DESCRIPTION
Also, fix a small typo.

https://wayland.freedesktop.org/libinput/doc/latest/group__config.html#ga56c9886b0161ecdb9b351d8dedc212e4